### PR TITLE
Fix Homebrew update trigger after releases

### DIFF
--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -1,20 +1,21 @@
 name: Update Homebrew Tap
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: [Build Binaries]
+    types: [completed]
 
 permissions: {}
 
 jobs:
   update-tap:
     runs-on: ubuntu-latest
-    if: ${{ !github.event.release.prerelease }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v') }}
     steps:
       - name: Update Homebrew formula
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.workflow_run.head_branch }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Summary

- trigger the Homebrew tap updater from successful tag-based `Build Binaries` workflow runs
- avoid relying on a `release.published` event suppressed when the release is created with `GITHUB_TOKEN`

## Validation

- workflow YAML parsed successfully
- `npm run check` passed in the commit hook

This prevents future Homebrew formula versions from lagging behind published OpenABCode releases.