### PR TITLE
Fix Homebrew tap token authentication

### DIFF
--- a/.github/workflows/update-homebrew-tap.yml
+++ b/.github/workflows/update-homebrew-tap.yml
@@ -4,18 +4,24 @@ on:
   workflow_run:
     workflows: [Build Binaries]
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Release tag to publish to Homebrew
+        required: true
+        type: string
 
 permissions: {}
 
 jobs:
   update-tap:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v')) }}
     steps:
       - name: Update Homebrew formula
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          RELEASE_TAG: ${{ github.event.workflow_run.head_branch }}
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.event.workflow_run.head_branch }}
         run: |
           set -euo pipefail
 
@@ -31,11 +37,8 @@ jobs:
             SHAS["${asset}"]="${sha}"
           done
 
-          # Clone tap repo
-          git clone "https://x-access-token:${GH_TOKEN}@github.com/${TAP_REPO}.git" tap
-          cd tap
-
           # Generate formula
+          mkdir -p "$(dirname "${FORMULA_PATH}")"
           cat > "${FORMULA_PATH}" << RUBY
           class Openabcode < Formula
             desc "AI coding agent with task routing and hosted gateway"
@@ -77,9 +80,11 @@ jobs:
           # Remove leading whitespace from heredoc
           sed -i 's/^          //' "${FORMULA_PATH}"
 
-          # Commit and push
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add "${FORMULA_PATH}"
-          git commit -m "openabcode ${VERSION}"
-          git push
+          # Update the tap with the fine-grained PAT as a Bearer token.
+          formula_sha=$(gh api "repos/${TAP_REPO}/contents/${FORMULA_PATH}" --jq '.sha')
+          formula_content=$(base64 -w 0 "${FORMULA_PATH}")
+          gh api --method PUT "repos/${TAP_REPO}/contents/${FORMULA_PATH}" \
+            -f message="openabcode ${VERSION}" \
+            -f content="${formula_content}" \
+            -f sha="${formula_sha}" \
+            -f branch=main


### PR DESCRIPTION
## Summary

- use `HOMEBREW_TAP_TOKEN` as a Bearer token through GitHub's Contents API
- avoid embedding a fine-grained PAT in a Git clone URL
- add a manual `release_tag` dispatch for end-to-end verification and recovery

## Validation

- workflow YAML parsed successfully
- `npm run check` passed
- commit hook passed the full repository checks

After merge, this will be manually dispatched for `v1.0.4` to verify the existing secret with the real tap repository.